### PR TITLE
Revert "new sleepy pi2 release fixes time incompatibility."

### DIFF
--- a/.github/workflows/arduino-test.yml
+++ b/.github/workflows/arduino-test.yml
@@ -25,9 +25,9 @@ jobs:
           PATH=~/bin:$PATH arduino-cli core update-index
           PATH=~/bin:$PATH arduino-cli core install ${{ matrix.arduino-platform }}
           PATH=~/bin:$PATH arduino-cli lib update-index
-          PATH=~/bin:$PATH arduino-cli lib install "Sleepy Pi 2@1.0.1"
+          PATH=~/bin:$PATH arduino-cli lib install "Sleepy Pi 2"
           PATH=~/bin:$PATH arduino-cli lib install PCF8523
-          PATH=~/bin:$PATH arduino-cli lib install "Time@1.6.1"
+          PATH=~/bin:$PATH arduino-cli lib install "Time@1.6.0"
           PATH=~/bin:$PATH arduino-cli lib install LowPower_LowPowerLab
           PATH=~/bin:$PATH arduino-cli lib install ArduinoJson
           PATH=~/bin:$PATH arduino-cli lib install CRC32

--- a/PiBuoy/sleepypi/sleepypi.ino
+++ b/PiBuoy/sleepypi/sleepypi.ino
@@ -10,7 +10,9 @@
 // * LowPower_LowPowerLab (needed for Sleepy Pi 2 lib)
 // * PCF8523
 // * Sleepy Pi 2
-// * Time 1.6.1
+// * Time 1.6
+//
+// TODO: upgrade Time, when Sleepy Pi 2 releases > 1.0.0.
 
 #include <CRC32.h>
 #include <ArduinoJson.h>


### PR DESCRIPTION
This reverts commit 39a87db350c4e521bbdcc5b2dcabdf5860a6d852.