### PR TITLE
Update group name for boto package rule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,7 @@
   "packageRules": [
     {
       "matchPackagePatterns": ["^boto"],
-      "groupName": "Update dependency botocore and boto3"
+      "groupName": "all boto dependencies"
     }
   ],
   "timezone": "America/New_York",


### PR DESCRIPTION
Apparently, renovate adds "Update" to the group name. So, this minor change makes the PR read better.