### PR TITLE
pytype 2022.10.13 gets confused by the global reference t as a Telem …

### DIFF
--- a/PiBuoyV2/services/sense/sense_app.py
+++ b/PiBuoyV2/services/sense/sense_app.py
@@ -544,6 +544,6 @@ class Telemetry:
 
 
 if __name__ == '__main__':
-    t = Telemetry()
-    t.init_sense()
-    t.main(True)
+    telem = Telemetry()
+    telem.init_sense()
+    telem.main(True)


### PR DESCRIPTION
…instance, and also t as a temperature reading.